### PR TITLE
add forerunner 245 support

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -28,6 +28,8 @@
             <iq:product id="fenixchronos"/>
             <iq:product id="fr230"/>
             <iq:product id="fr235"/>
+            <iq:product id="fr245"/>
+            <iq:product id="fr245m"/>
             <iq:product id="fr630"/>
             <iq:product id="fr645"/>
             <iq:product id="fr645m"/>


### PR DESCRIPTION
Hi @klimeryk,
I just add a forerunner 245 (245 and 245 music) family support, did the tests and it seems good.

You need recompile with the new Garmin SDK (3.0.11) - see https://forums.garmin.com/developer/connect-iq/b/news-announcements/posts/3-0-11-sdk-out-now-tag-newdevices