### PR TITLE
Run in background

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -22,19 +22,19 @@
             <iq:product id="descentmk2s"/>
             <iq:product id="descentmk343mm"/>
             <iq:product id="descentmk351mm"/>
+            <iq:product id="edge1030"/>
+            <iq:product id="edge1030bontrager"/>
+            <iq:product id="edge1030plus"/>
+            <iq:product id="edge1040"/>
+            <iq:product id="edge1050"/>
             <iq:product id="edge520plus"/>
             <iq:product id="edge530"/>
             <iq:product id="edge540"/>
             <iq:product id="edge820"/>
             <iq:product id="edge830"/>
             <iq:product id="edge840"/>
-            <iq:product id="edge1030"/>
-            <iq:product id="edge1030bontrager"/>
-            <iq:product id="edge1030plus"/>
-            <iq:product id="edge1040"/>
-            <iq:product id="edge1050"/>
-            <iq:product id="edge_520"/>
             <iq:product id="edge_1000"/>
+            <iq:product id="edge_520"/>
             <iq:product id="edgeexplore"/>
             <iq:product id="edgeexplore2"/>
             <iq:product id="enduro"/>
@@ -65,13 +65,12 @@
             <iq:product id="fenix7x"/>
             <iq:product id="fenix7xpro"/>
             <iq:product id="fenix7xpronowifi"/>
-            <iq:product id="fenix8solar47mm"/>
-            <iq:product id="fenix8solar51mm"/>
             <iq:product id="fenix843mm"/>
             <iq:product id="fenix847mm"/>
+            <iq:product id="fenix8solar47mm"/>
+            <iq:product id="fenix8solar51mm"/>
             <iq:product id="fenixchronos"/>
             <iq:product id="fenixe"/>
-            <iq:product id="fr55"/>
             <iq:product id="fr165"/>
             <iq:product id="fr165m"/>
             <iq:product id="fr230"/>
@@ -84,6 +83,7 @@
             <iq:product id="fr255sm"/>
             <iq:product id="fr265"/>
             <iq:product id="fr265s"/>
+            <iq:product id="fr55"/>
             <iq:product id="fr630"/>
             <iq:product id="fr645"/>
             <iq:product id="fr645m"/>
@@ -139,7 +139,9 @@
             <iq:product id="vivoactive5"/>
             <iq:product id="vivoactive_hr"/>
         </iq:products>
-        <iq:permissions/>
+        <iq:permissions>
+            <iq:uses-permission id="Background"/>
+        </iq:permissions>
         <iq:languages>
             <iq:language>eng</iq:language>
             <iq:language>pol</iq:language>

--- a/resources/settings/settings.xml
+++ b/resources/settings/settings.xml
@@ -1,12 +1,12 @@
 <settings>
 	<setting propertyKey="@Properties.pomodoroLength" title="@Strings.PomodoroLength">
-		<settingConfig type="numeric" min="1" />
+		<settingConfig type="numeric" min="5" />
 	</setting>
 	<setting propertyKey="@Properties.shortBreakLength" title="@Strings.ShortBreakLength">
-		<settingConfig type="numeric" min="1" />
+		<settingConfig type="numeric" min="5" />
 	</setting>
 	<setting propertyKey="@Properties.longBreakLength" title="@Strings.LongBreakLength">
-		<settingConfig type="numeric" min="1" />
+		<settingConfig type="numeric" min="5" />
 	</setting>
 	<setting propertyKey="@Properties.numberOfPomodorosBeforeLongBreak" title="@Strings.NumberOfPomodorosBeforeLongBreak">
 		<settingConfig type="numeric" min="1" />

--- a/source/GarmodoroApp.mc
+++ b/source/GarmodoroApp.mc
@@ -1,23 +1,17 @@
 using Toybox.Application as App;
-using Toybox.Timer as Timer;
+using Toybox.System;
 
+(:background)
 class GarmodoroApp extends App.AppBase {
+  function initialize() {
+    AppBase.initialize();
+  }
 
-	function initialize() {
-		AppBase.initialize();
-	}
+  function getInitialView() {
+    return [new GarmodoroView(), new GarmodoroDelegate()];
+  }
 
-	function onStart(state) {
-		timer = new Timer.Timer();
-		tickTimer = new Timer.Timer();
-	}
-
-	function onStop(state) {
-		tickTimer.stop();
-		timer.stop();
-	}
-
-	function getInitialView() {
-		return [ new GarmodoroView(), new GarmodoroDelegate() ];
-	}
+  public function getServiceDelegate() as [System.ServiceDelegate] {
+    return [new GarmodoroServiceDelegate()];
+  }
 }

--- a/source/GarmodoroPersistentStorage.mc
+++ b/source/GarmodoroPersistentStorage.mc
@@ -1,0 +1,49 @@
+using Toybox.Time;
+using Toybox.Background;
+using Toybox.Math;
+using Toybox.Application.Storage;
+
+const ENDTIME_PROPERTY_STORAGE_KEY = "end_time";
+const POMODORO_NUMBER_PROPERTY_STORAGE_KEY = "pomodoro_number";
+const POMODORO_TIMER_STARTED_PROPERTY_STORAGE_KEY = "pomodoro_timer_started";
+const BREAK_TIMER_STARTED_PROPERTY_STORAGE_KEY = "break_timer_started";
+
+function setEndTimeBySeconds(seconds) {
+  var date =
+    seconds != null ? Time.now().add(new Time.Duration(seconds)).value() : null;
+  Storage.setValue(ENDTIME_PROPERTY_STORAGE_KEY, date);
+  if (Background.getTemporalEventRegisteredTime() != null) {
+    Background.deleteTemporalEvent();
+  }
+  if (seconds != null) {
+    Background.registerForTemporalEvent(new Time.Duration(seconds));
+  }
+}
+
+function setStorageValue(key, value) {
+  Storage.setValue(key, value);
+}
+
+function getStorageValue(key, defaultValue) {
+  var value = Storage.getValue(key);
+  return value != null ? value : defaultValue;
+}
+
+function getSeconds() {
+  var currentTime = Time.now();
+  var endTime = getStorageValue(ENDTIME_PROPERTY_STORAGE_KEY, null);
+  if (endTime == null) {
+    return null;
+  }
+  var remainingSeconds = endTime - currentTime.value();
+  return remainingSeconds;
+}
+
+function getMinutes() {
+  var remainingSeconds = getSeconds();
+  if (remainingSeconds == null) {
+    return null;
+  }
+  var remainingMinutes = Math.ceil(remainingSeconds.toFloat() / 60); // Convert seconds to minutes
+  return remainingMinutes;
+}

--- a/source/GarmodoroServiceDelegate.mc
+++ b/source/GarmodoroServiceDelegate.mc
@@ -1,0 +1,111 @@
+using Toybox.System;
+using Toybox.Application.Storage;
+using Toybox.Time;
+using Toybox.Application as App;
+
+(:background)
+class GarmodoroServiceDelegate extends System.ServiceDelegate {
+  hidden function getStorageValue(key, defaultValue) {
+    var value = Storage.getValue(key);
+    return value != null ? value : defaultValue;
+  }
+
+  hidden function setStorageValue(key, value) {
+    Storage.setValue(key, value);
+  }
+
+  hidden function getSeconds() {
+    var currentTime = Time.now();
+    var endTime = getStorageValue(ENDTIME_PROPERTY_STORAGE_KEY, null);
+    if (endTime == null) {
+      return null;
+    }
+    var remainingSeconds = endTime - currentTime.value();
+    return remainingSeconds;
+  }
+
+  public function onTemporalEvent() as Void {
+    var seconds = me.getSeconds();
+    if (seconds <= 60) {
+      var isPomodoroTimerStarted = getStorageValue(
+        POMODORO_TIMER_STARTED_PROPERTY_STORAGE_KEY,
+        false
+      );
+      var isBreakTimerStarted = getStorageValue(
+        BREAK_TIMER_STARTED_PROPERTY_STORAGE_KEY,
+        false
+      );
+
+      if (isPomodoroTimerStarted) {
+        me.pomodoroLogic();
+        var message = isLongBreak()
+          ? "Pomodoro is over. Take a long break."
+          : "Pomodoro is over. Take a short break.";
+        Background.requestApplicationWake(message);
+      }
+
+      if (isBreakTimerStarted) {
+        me.breakLogic();
+        Background.requestApplicationWake(
+          "Break is over. Time to start a pomodoro."
+        );
+      }
+      Background.exit(null);
+    }
+  }
+
+  public function breakLogic() {
+    me.setStorageValue(BREAK_TIMER_STARTED_PROPERTY_STORAGE_KEY, false);
+    var pomodoroNumber = getStorageValue(
+      POMODORO_NUMBER_PROPERTY_STORAGE_KEY,
+      1
+    );
+    me.setStorageValue(
+      POMODORO_NUMBER_PROPERTY_STORAGE_KEY,
+      pomodoroNumber + 1
+    );
+    me.setStorageValue(POMODORO_TIMER_STARTED_PROPERTY_STORAGE_KEY, true);
+    resetMinutes();
+  }
+
+  public function pomodoroLogic() {
+    setStorageValue(POMODORO_TIMER_STARTED_PROPERTY_STORAGE_KEY, false);
+    var breakLengthInMinutes = App.getApp().getProperty(
+      isLongBreak() ? "longBreakLength" : "shortBreakLength"
+    );
+    setEndTimeBySeconds(breakLengthInMinutes * 60);
+    setStorageValue(BREAK_TIMER_STARTED_PROPERTY_STORAGE_KEY, true);
+  }
+
+  function isLongBreak() {
+    var pomodoroNumber = getStorageValue(
+      POMODORO_NUMBER_PROPERTY_STORAGE_KEY,
+      1
+    );
+    return (
+      pomodoroNumber %
+        App.getApp().getProperty("numberOfPomodorosBeforeLongBreak") ==
+      0
+    );
+  }
+
+  function resetMinutes() {
+    var minutes = App.getApp().getProperty("pomodoroLength");
+    var minutesAsSeconds = minutes * 60;
+    setEndTimeBySeconds(minutesAsSeconds);
+  }
+
+  function setEndTimeBySeconds(seconds) {
+    var date =
+      seconds != null
+        ? Time.now().add(new Time.Duration(seconds)).value()
+        : null;
+    Storage.setValue(ENDTIME_PROPERTY_STORAGE_KEY, date);
+    if (Background.getTemporalEventRegisteredTime() != null) {
+      Background.deleteTemporalEvent();
+    }
+    if (seconds != null) {
+      Background.registerForTemporalEvent(new Time.Duration(seconds));
+    }
+  }
+}

--- a/source/GarmodoroView.mc
+++ b/source/GarmodoroView.mc
@@ -55,6 +55,9 @@ class GarmodoroView extends Ui.View {
 	function onUpdate( dc ) {
 		dc.setColor( Gfx.COLOR_TRANSPARENT, Gfx.COLOR_BLACK );
 		dc.clear();
+		var isBreakTimerStarted = getStorageValue(BREAK_TIMER_STARTED_PROPERTY_STORAGE_KEY, false);
+		var isPomodoroTimerStarted = getStorageValue(POMODORO_TIMER_STARTED_PROPERTY_STORAGE_KEY, false);
+		var pomodoroNumber = getStorageValue(POMODORO_NUMBER_PROPERTY_STORAGE_KEY, 1);
 		if ( isBreakTimerStarted ) {
 			dc.setColor( Gfx.COLOR_GREEN, Gfx.COLOR_TRANSPARENT );
 			dc.drawText( me.centerX, me.pomodoroOffset, Gfx.FONT_MEDIUM, isLongBreak() ? me.longBreakLabel : me.shortBreakLabel, Gfx.TEXT_JUSTIFY_CENTER );
@@ -82,6 +85,7 @@ class GarmodoroView extends Ui.View {
 	}
 
 	hidden function drawMinutes( dc ) {
+		var minutes = getMinutes();
 		dc.drawText( me.centerX, me.minutesOffset, Gfx.FONT_NUMBER_THAI_HOT, minutes.format( "%02d" ), Gfx.TEXT_JUSTIFY_CENTER );
 	}
 

--- a/source/StopMenuDelegate.mc
+++ b/source/StopMenuDelegate.mc
@@ -16,10 +16,13 @@ class StopMenuDelegate extends Ui.MenuInputDelegate {
 			timer.stop();
 
 			resetMinutes();
-			pomodoroNumber = 1;
-			isPomodoroTimerStarted = false;
-			isBreakTimerStarted = false;
-			timer.start( method( :idleCallback ), 60 * 1000, true );
+			setStorageValue(POMODORO_TIMER_STARTED_PROPERTY_STORAGE_KEY, false);
+			setStorageValue(BREAK_TIMER_STARTED_PROPERTY_STORAGE_KEY, false);
+			setStorageValue(POMODORO_NUMBER_PROPERTY_STORAGE_KEY, 1);
+
+			setEndTimeBySeconds(null);
+			Background.deleteTemporalEvent();			
+			timer.start( method( :idleCallback ), 10 * 1000, true );
 
 			Ui.requestUpdate();
 		} else if ( item == :exit ) {


### PR DESCRIPTION
@klimeryk Thanks for this app! I wanted to use it, but I didn’t want to keep the app open all the time. I also wanted to receive notifications, see my watch face, etc. So, I modified the application to spawn a temporary background process that notifies the user when a Pomodoro session or break is over.

I also noticed many reviews mentioning battery drain. I haven’t used the app long enough to observe this myself, but perhaps this change helps mitigate the issue since the app is only active when the timer runs out.

Some limitations:
Garmin requires a minimum of 5 minutes for a temporary background process. As a result, the shortest possible Pomodoro or break duration is now 5 minutes instead of 1. (But who would want anything shorter than 5 minutes anyway?)
Resources cannot be accessed in the background, so the notification text is now hardcoded in the codebase and always in English. (Do you happen to know a way to access resources in the background?)